### PR TITLE
Allow to pass apadter-specific Configs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }],
     "require": {
         "illuminate/support": "^5.0 || ^6.0",
-		"illuminate/filesystem": "^5.0 || ^6.0",
+        "illuminate/filesystem": "^5.0 || ^6.0",
         "league/flysystem": "^1.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "email": "danhunsaker@gmail.com"
     }],
     "require": {
-        "illuminate/support": "^5.0",
-        "illuminate/filesystem": "^5.0",
+        "illuminate/support": "^5.0 || ^6.0",
+		"illuminate/filesystem": "^5.0 || ^6.0",
         "league/flysystem": "^1.0"
     },
     "suggest": {

--- a/src/FlysystemManager.php
+++ b/src/FlysystemManager.php
@@ -310,7 +310,7 @@ class FlysystemManager extends FilesystemManager
      * @param  array  $config
      * @return \League\Flysystem\FlysystemInterface
      */
-    protected function createFlysystem(AdapterInterface $adapter, array $config)
+    protected function createFlysystem(AdapterInterface $adapter, array $config, array $driverConfig = null)
     {
         if (class_exists('League\Flysystem\EventableFilesystem\EventableFilesystem')) {
             $fsClass = \League\Flysystem\EventableFilesystem\EventableFilesystem::class;
@@ -323,6 +323,7 @@ class FlysystemManager extends FilesystemManager
         }
 
         $config = Arr::only($config, ['visibility']);
+		$config = array_merge($config, $driverConfig);
 
         return new $fsClass($adapter, count($config) > 0 ? $config : null);
     }

--- a/src/FlysystemManager.php
+++ b/src/FlysystemManager.php
@@ -323,7 +323,7 @@ class FlysystemManager extends FilesystemManager
         }
 
         $config = Arr::only($config, ['visibility']);
-		$config = array_merge($config, $driverConfig);
+		$config = array_merge($config, (array) $driverConfig);
 
         return new $fsClass($adapter, count($config) > 0 ? $config : null);
     }

--- a/src/FlysystemManager.php
+++ b/src/FlysystemManager.php
@@ -323,7 +323,7 @@ class FlysystemManager extends FilesystemManager
         }
 
         $config = Arr::only($config, ['visibility']);
-		$config = array_merge($config, (array) $driverConfig);
+        $config = array_merge($config, (array) $driverConfig);
 
         return new $fsClass($adapter, count($config) > 0 ? $config : null);
     }


### PR DESCRIPTION
This little PR will allow to pass the custom configurations for a (non-)standard driver.

For a practical example check [this PR in laravel-flysystem-others](https://github.com/danhunsaker/laravel-flysystem-others/pull/7)